### PR TITLE
Require 'bigdecimal' - adjust to Ruby 2.5.0

### DIFF
--- a/lib/taxger/lohnsteuer/bigdecimal.rb
+++ b/lib/taxger/lohnsteuer/bigdecimal.rb
@@ -1,3 +1,5 @@
+require 'bigdecimal'
+
 module Taxger
   module Lohnsteuer
     class BigDecimal < Numeric::BigDecimal

--- a/lib/taxger/lohnsteuer/bigdecimal.rb
+++ b/lib/taxger/lohnsteuer/bigdecimal.rb
@@ -2,7 +2,7 @@ require 'bigdecimal'
 
 module Taxger
   module Lohnsteuer
-    class BigDecimal < Numeric::BigDecimal
+    class BigDecimal < BigDecimal
       def multiply(value)
         BigDecimal.new(self * value)
       end

--- a/lib/taxger/version.rb
+++ b/lib/taxger/version.rb
@@ -1,3 +1,3 @@
 module Taxger
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Prepares gem for Ruby 2.5.0